### PR TITLE
CompatHelper: add new compat entry for StatsBase at version 0.34, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+StatsBase = "0.34"


### PR DESCRIPTION
This pull request sets the compat entry for the `StatsBase` package to `0.34`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.