### PR TITLE
CompatHelper: bump compat for StatsBase to 0.34, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ DifferentialEquations = "^7.13.0"
 Distributions = "^0.25.109"
 MicrobiomeAnalysis = "^0.4.0"
 Plots = "^1.40.4"
-StatsBase = "^0.33.21"
+StatsBase = "^0.33.21, 0.34"
 julia = "^1.6"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `StatsBase` package from `^0.33.21` to `^0.33.21, 0.34`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.